### PR TITLE
Classwork 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,60 @@
+//SingleFieldIndex
+db.student.createIndex({"class_id":551},
+{
+"createdCollectionAutomatically" :
+false,
+"numIndexesBefore": 1,
+"numIndexsAfter": 2,
+"ok" : 1
+})
+
+< class_id_551
+> db.student.getIndexes()
+
+
+//CompoundIndex
+  db.student.createIndex({student_id: 777777, student_id: 223344},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_id_223344
+> db.student.getIndexes()
+
+
+//MultikeyIndex
+db.student.createIndex({student:1},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_1
+> db.student.getIndexes()
+
+
+//GeoSpatial
+db.student.createIndex({"score":"2dsphere"},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< score_2dsphere
+> db.student.getIndexes()
+
+//Dropindex
+db.student.dropIndex({key: {student_id:551}},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})


### PR DESCRIPTION
Indexing:
Indexing in MongoDB is a crucial aspect of database optimization, as it helps improve query performance by allowing the database engine to locate and retrieve documents more efficiently.
Here are the basic steps to create and use indexes in MongoDB:
1. Single Field Index: A single field index in MongoDB is an index that is created on a single field within a document in a MongoDB collection.
![311016384-6a8d2b2e-c25a-4e1b-8d0b-b94e94cf743c](https://github.com/RohitKumar710/MongoDB/assets/65115705/821e5733-378a-4be7-a3f7-f31af371028d)
2. Compound Index : A compound index in MongoDB is an index created on multiple fields within a document in a MongoDB collection. Unlike a single field index, which is created on a single field, a compound index involves multiple fields. This type of index can be beneficial when queries involve multiple criteria or when sorting and filtering are performed on multiple fields simultaneously.
Here's an example of creating a compound index in MongoDB:
![311017098-cfb804d3-cf80-46ee-bfbe-70844c3e5570](https://github.com/RohitKumar710/MongoDB/assets/65115705/b2791b6a-aa90-4e87-8c70-46623d05bd88)
3.Multi-Key Index: A multi-key index in MongoDB is an index that is created on an array field, where each element of the array is indexed separately. This allows MongoDB to efficiently index and query documents based on the values within arrays. Multi-key indexes are particularly useful when dealing with fields that contain arrays of values.
Here's an example of creating a multi-key index in MongoDB:
![311018885-dea9cfa2-2966-4b00-b92a-5722fc037dd9](https://github.com/RohitKumar710/MongoDB/assets/65115705/c65d7b7b-e863-4b46-9a2e-570e324149e8)
4. Geospatial Indexes: Geospatial indexes in MongoDB are specialized indexes that support efficient queries involving geographical data. MongoDB provides two types of geospatial indexes: 2d indexes and 2dsphere indexes. These indexes are designed to optimize the retrieval of documents based on their spatial coordinates, making it easier to perform location-based queries.
![311019309-6663bee0-d8e7-4fe6-b4e5-6e8804c0fa1f](https://github.com/RohitKumar710/MongoDB/assets/65115705/7e42ae0e-94e5-46b9-a98e-b5cde4e7bef3)
5. Dropping an Index: Dropping an index in MongoDB is a straightforward process. You can use the dropIndex() method to remove an existing index from a collection.
Here's the basic syntax:
db.collection.dropIndex("index_name")
![311019855-ea346b21-0c67-4ae5-82db-e2974d5736e9](https://github.com/RohitKumar710/MongoDB/assets/65115705/7bd066e2-e09e-466c-9e3e-e53ac4a7dbdf)